### PR TITLE
Fix dev port settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack -p 9002",
+    "dev": "next dev --turbopack",
     "genkit:dev": "genkit start -- tsx src/ai/dev.ts",
     "genkit:watch": "genkit start -- tsx --watch src/ai/dev.ts",
     "build": "next build",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Page() {
+  return <div>Hello World</div>;
+}


### PR DESCRIPTION
## Summary
- fix `npm run dev` port overriding by removing hardcoded port
- create placeholder `src/app/page.tsx`

## Testing
- `npm run typecheck` *(fails: Cannot find module 'next' and others)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845cc79899c8322a22e42244d94b198